### PR TITLE
docs: address documentation review findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```bash
 uv sync --group dev          # install deps + dev tools
-uv run pytest -q             # run all tests (95 tests)
+uv run pytest -q             # run all tests (152 tests)
 uv run pytest tests/test_schema.py -q                 # run one test file
 uv run pytest tests/test_schema.py::TestSerialization  # run one test class
 uv run ruff check src/ tests/                          # lint
@@ -33,9 +33,10 @@ pending → claimed → building → running → completed
 src/protocol/    Shared: TestRequest, status constants, StatusLiteral, extract_metric
 src/agent/       Workstation: optimization loop, Claude API, git ops, history tracking
 src/runner/      Lab machine: build DPDK, run testpmd/DTS, push results
+src/perf/        Profiling: perf record orchestration, stack analysis, arch profiles, diff comparison
 ```
 
-**Import rule:** `agent/` and `runner/` both import from `protocol/`, never from each other. Always import from `src.protocol` (the facade), not `src.protocol.schema` directly.
+**Import rules:** `agent/` and `runner/` both import from `protocol/`, never from each other. `runner/` imports from `perf/` for profiling captures; `agent/` displays profiling output but does not import `perf/` directly. Always import from `src.protocol` (the facade), not `src.protocol.schema` directly.
 
 ### Agent modules
 
@@ -46,6 +47,7 @@ src/runner/      Lab machine: build DPDK, run testpmd/DTS, push results
 - `strategy.py` — `format_context()` for prompt building, `validate_change()` for submodule diff
 - `history.py` — TSV-based results/failures tracking
 - `metric.py` — `compare_metric()` with `Direction` Literal type
+- `protocol.py` — request creation (`create_request()`), sequence numbering, `poll_for_completion()`
 
 ### Runner modules
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ src/
   agent/       Agent loop, protocol, history, metric, strategy
   runner/      Runner service, build, testpmd, execute (DTS), protocol
   protocol/    Shared schema (TestRequest dataclass)
+  perf/        Profiling: perf record, stack analysis, arch profiles
   logging_config.py  Shared logging setup
 config/
   campaign.toml           Campaign settings (metric, goal, test backend, scope)

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -40,6 +40,7 @@ on startup (override with `--campaign <path>`).
 | `[dpdk]` | `submodule_path` | Path to the DPDK submodule (default: `"dpdk"`) |
 | `[dpdk]` | `optimization_branch` | Branch in submodule for good changes (default: `"autosearch/optimize"`) |
 | `[dpdk]` | `scope` | Source paths the agent may modify (relative to submodule) |
+| `[profiling]` | `enabled` | Include profiling summary in results sent to the agent (default: `false`) |
 
 ## Interactive mode
 
@@ -81,8 +82,16 @@ uv run autosearch --autonomous
 ```
 
 The agent shows Claude's proposal and prompts `Apply this change? [y/N/quit]`.
-After you apply the change and commit in the submodule, the agent submits the
-request and polls for results as usual. Use `--dry-run` to test locally.
+
+To apply a proposal:
+1. Read Claude's description of which files to modify and what to change.
+2. Make the edits manually in the `dpdk/` submodule.
+3. Commit the changes inside `dpdk/` (`git -C dpdk commit -am "..."`).
+4. Press `y` at the prompt.
+
+The agent then submits the request and polls for results. Press `N` to skip
+the proposal without applying it; Claude will propose something different next
+iteration. Use `--dry-run` to test locally.
 
 ## CLI reference
 
@@ -105,6 +114,14 @@ Each iteration appends a row to `results.tsv` with columns:
 - `metric_value` — extracted metric (empty if failed/timed out)
 - `status` — `completed`, `failed`, `timed_out`, or `dry_run`
 - `description` — user-provided or Claude-generated change description
+
+Failed attempts are recorded in `failures.tsv` with columns:
+
+- `timestamp` — ISO 8601 UTC
+- `dpdk_commit` — DPDK submodule HEAD of the reverted change
+- `metric_value` — measured value that didn't improve
+- `description` — change description
+- `diff_summary` — summary of the reverted diff
 
 Request JSON files in `requests/` follow the naming pattern
 `{seq:04d}_{isodate}.json` and track the full lifecycle:

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -44,6 +44,9 @@ cp config/runner.toml.example config/runner.toml
 | `[build]` | `jobs` | Parallel build jobs (0 = all cores) |
 | `[build]` | `cross_file` | Meson cross-file for cross-compiling (empty for native) |
 | `[build]` | `extra_meson_args` | Additional meson setup arguments |
+| `[profiling]` | `enabled` | Capture `perf` profiles during testpmd measurement window (default: `false`) |
+| `[profiling]` | `frequency` | Sampling frequency in Hz (default: `99`) |
+| `[profiling]` | `sudo` | Run `perf` with sudo — must match `testpmd.sudo` (default: `true`) |
 
 Override the config path with the `AUTOSEARCH_CONFIG` environment variable.
 The log level can also be set via the `LOG_LEVEL` environment variable.
@@ -89,11 +92,48 @@ Set `sudo = false` in `[testpmd]` if the runner service already runs as root.
 ### DTS
 
 Runs the DPDK Test Suite via `poetry run ./main.py` in the DTS directory.
-Requires `[paths].dts_dir` in `runner.toml` and DTS topology files
-(`nodes.yaml`, `test_run.yaml`) configured separately.
+Requires `[paths].dts_dir` in `runner.toml` and DTS topology files.
+Copy `config/nodes.yaml.example` → `config/nodes.yaml` and
+`config/test_run.yaml.example` → `config/test_run.yaml` and fill in your
+topology.
 
 Set `backend = "dts"` in `config/campaign.toml` and configure the metric path
 to match the DTS JSON result structure.
+
+### Profiling
+
+When enabled, the runner captures `perf` profiles during the testpmd
+measurement window. The profiling data (folded stacks and hardware counters)
+is summarized and attached to the request results, giving the agent insight
+into where CPU cycles are spent.
+
+**Prerequisites:**
+- Linux `perf` tool installed (`perf` or `linux-tools-$(uname -r)`)
+- Kernel support for hardware performance counters
+- If `profiling.sudo = true`: passwordless sudo for `perf` (same pattern as testpmd above)
+
+**Enable in `config/runner.toml`:**
+
+```toml
+[profiling]
+enabled = true
+frequency = 99    # sampling Hz (99 avoids timer aliasing)
+sudo = true       # must match [testpmd].sudo when profiling testpmd
+```
+
+Also set `[profiling].enabled = true` in `config/campaign.toml` so the agent
+receives the profiling summary in its prompt context.
+
+**What happens at runtime:**
+1. `perf record` attaches to the testpmd process for the measurement window
+2. Stacks are folded and parsed into a top-functions / hot-paths summary
+3. Hardware counters (`perf stat`) capture IPC, cache misses, branch misses
+4. The summary is included in the request result pushed back to the agent
+
+The profiling library lives in `src/perf/`: `profile.py` (capture),
+`analyze.py` (stack analysis and diagnostics), `arch.py` (architecture
+detection and PMU event profiles), `diff.py` (differential comparison between
+runs), and `gate.py` (CI regression gate with pass/warn/fail thresholds).
 
 ## Running
 
@@ -124,8 +164,14 @@ sudo systemctl enable --now autosearch-runner
 ```
 
 The service unit expects:
-- `ExecStart=/usr/local/bin/autosearch-runner` — create a wrapper script or
-  symlink to `uv run python -m src.runner.service` in your checkout
+- `ExecStart=/usr/local/bin/autosearch-runner` — two options:
+  1. Create a wrapper script at `/usr/local/bin/autosearch-runner`:
+     ```bash
+     #!/bin/sh
+     cd /path/to/checkout && exec .venv/bin/python -m src.runner.service "$@"
+     ```
+  2. Install the runner package into a venv (`uv pip install /path/to/checkout`)
+     and point `ExecStart` at the installed `autosearch-runner` binary
 - `User=dpdk` — runs as a dedicated `dpdk` user
 - `AUTOSEARCH_CONFIG=/etc/autosearch/runner.toml` — config path override
 - `ReadWritePaths=/var/lib/autosearch /tmp` — writable paths for build artifacts


### PR DESCRIPTION
## Summary

- Add `[profiling]` config keys to runner and agent config tables
- Add new Profiling section to runner guide covering prerequisites, config, runtime behavior, and `src/perf/` modules
- Document `failures.tsv` columns alongside existing `results.tsv` documentation
- Clarify autonomous mode with explicit 4-step workflow
- Add `protocol.py` to CLAUDE.md agent modules list
- Add `src/perf/` to package boundaries (CLAUDE.md) and project layout (README.md)
- Update stale test count (95 → 152)
- Clarify systemd ExecStart with two concrete deployment options
- Add DTS config example file pointers (`nodes.yaml.example`, `test_run.yaml.example`)

## Test plan

- [ ] Verify markdown tables render correctly on GitHub
- [ ] Cross-check `[profiling]` keys against `runner.toml.example` and `campaign.toml`
- [ ] Verify all `.py` files in `src/agent/` and `src/perf/` are mentioned in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)